### PR TITLE
CMXML time milliseconds

### DIFF
--- a/PrivateCommands/Get-LogEntryFromCMXML.ps1
+++ b/PrivateCommands/Get-LogEntryFromCMXML.ps1
@@ -61,7 +61,7 @@ http://www.JPScripter.com
             if ($AllDetails.IsPresent){
                 $DetailsHash += $Loghash
             }
-            $DateTimeString = "$($Loghash['Date']) $($Loghash['time'].split('.')[0])"
+            $DateTimeString = "$($Loghash['Date']) $($Loghash['time'].split('-').split('+')[0])"
             $datetime = 0
             $Null = [datetime]::TryParse($DateTimeString, [ref] $datetime)
             $entry.datetime = $datetime


### PR DESCRIPTION
capture the log entry milliseconds for more accurate parsing